### PR TITLE
Sat, 10 Jun 2017 00:17:53 CST

### DIFF
--- a/gfw_whitelist.txt
+++ b/gfw_whitelist.txt
@@ -160,6 +160,7 @@
 ||csdnimg.cn
 ||css.net
 ||ctrip.com
+||chsi.com.cn
 
 ! D
 ||d7vg.com
@@ -556,6 +557,7 @@
 ||yunpian.com
 ||yunshipei.com
 ||yy.com
+||ynzs.cn
 
 ! Z
 ||zcool.com.cn


### PR DESCRIPTION
Add chsi.com.cn (China Student Info Identification Center) and ynzs.cn(The Admission Office of Yunnan Province) to the whitelist, which I found was not bypassed while registering on them,