### PR TITLE
对部分冷门网站进行的更新，以及一些常见网站进行相关补充

### DIFF
--- a/gfw_whitelist.txt
+++ b/gfw_whitelist.txt
@@ -145,6 +145,7 @@
 ||blizzardgames.cn
 ||blogjava.net
 ||boc.cn
+||bookfere.com
 ||bootcdn.cn
 ||bootcss.com
 ||bqtalk.com
@@ -179,6 +180,7 @@
 ||cli.im
 ||cloudinary.com
 ||cloudxns.net
+||cn.engadget.com
 ||cnbeta.com
 ||cnblogs.com
 ||cnki.net
@@ -199,6 +201,7 @@
 ||css.net
 ||css.network
 ||ct10000.com
+||ctfile.com
 ||ctrip.com
 
 ! D
@@ -231,12 +234,15 @@
 ||duoshuo.com
 ||duowan.com
 ||dwstatic.com
+||dxy.cn
+||dxycdn.com
 ||dygod.net
 
 ! E
 ||eastmoney.com
 ||eeboard.com
 ||elemecdn.com
+||els-cdn.com
 ||elsevier.com
 ||enkj.com
 ||eqoe.cn
@@ -257,6 +263,8 @@
 ||ganji.com
 ||gank.io
 ||gaokao.com
+||gbw-china.com
+||gbw365.com
 ||geetest.com
 ||getfedora.org
 ||getui.com
@@ -340,6 +348,7 @@
 ||jb51.net
 ||jcodecraeer.com
 ||jd.com
+||jd.hk
 ||jfrft.com
 ||jhdec.com
 ||jianguoyun.com
@@ -471,6 +480,7 @@
 ||pingwest.com
 ||playubuntu.cn
 ||plu.cn
+||pnas.org
 ||pptv.com
 ||psnine.com
 ||pythonclub.org
@@ -570,6 +580,7 @@
 ! T
 ||t.tt
 ||tanx.com
+||tansoole.com
 ||taobao.com
 ||taobaocdn.com
 ||tbcdn.cn
@@ -581,6 +592,7 @@
 ||thepaper.cn
 ||thinkphp.cn
 ||thomsonreuters.com
+||tianxun.com
 ||tianya.cn
 ||tietuku.com
 ||tigerlust.com
@@ -642,6 +654,7 @@
 ||wisenjoy.com
 ||wiz.cn
 ||wodemo.com
+||wolcavi.com
 ||woyoo.com
 
 ! X
@@ -686,6 +699,7 @@
 ! Z
 ||zaih.com
 ||zcool.com.cn
+||zdfans.com
 ||zhan.com
 ||zhangyao.name
 ||zhanqi.tv

--- a/gfw_whitelist.txt
+++ b/gfw_whitelist.txt
@@ -291,6 +291,7 @@
 ||hikvision.com
 ||hitokoto.cn
 ||hiwifi.com
+||hjenglish.com
 ||hostker.com
 ||huaban.com
 ||huanmusic.com
@@ -709,7 +710,7 @@
 ||zhimg.com
 ||zhiziyun.com
 ||zhujike.com
-||zimuzu.tv
+||zimuzu.io
 ||znyj365.com
 ||zol.com.cn
 ||zuk.cn

--- a/gfw_whitelist.txt
+++ b/gfw_whitelist.txt
@@ -67,6 +67,8 @@
 ||56.com
 ||58.com
 ||58pic.com
+||5eplay.com
+||5ewin.com
 
 ! 6
 ||6.cn
@@ -82,6 +84,7 @@
 ||91.com
 
 ! A
+||abchina.com
 ||acfun.cn
 ||acfun.tv
 ||acg.tv
@@ -125,11 +128,13 @@
 ||baidustatic.com
 ||bankcomm.com
 ||baozoumanhua.com
+||basechem.org
 ||battlenet.com.cn
 ||bdimg.com
 ||bdstatic.com
 ||behe.com
 ||beianbeian.com
+||biaozhuns.com
 ||bilibili.com
 ||biligame.com
 ||biligame.net
@@ -148,6 +153,7 @@
 
 ! C
 ||cachemoment.com
+||caixin.com
 ||cas.cn
 ||cctv.com
 ||cdn.jsdelivr.net
@@ -159,6 +165,8 @@
 ||ce.cn
 ||ceair.com
 ||cee.network
+||ch.com
+||changba.com
 ||china.com
 ||chinassl.net
 ||chinaunix.net
@@ -182,6 +190,7 @@
 ||coding.net
 ||coolapk.com
 ||coolpad.com
+||cqvip.com
 ||csair.com
 ||csdn.net
 ||csdnimg.cn
@@ -244,6 +253,7 @@
 ||gamersky.com
 ||ganji.com
 ||gank.io
+||gaokao.com
 ||geetest.com
 ||getfedora.org
 ||getui.com
@@ -276,6 +286,7 @@
 ||huanqiu.com
 ||huawei.com
 ||huomao.com
+||huomaotv.cn
 ||huiji.wiki
 ||huijistatic.com
 ||huijiwiki.com
@@ -310,6 +321,7 @@
 ||iplaysoft.com
 ||iqing.in
 ||iqiyi.com
+||iqiyipic.com
 ||it168.com
 ||itc.cn
 ||itellyou.cn
@@ -334,6 +346,7 @@
 ||jisuanke.com
 ||jomodns.com
 ||joyyang.com
+||jstor.org
 
 ! K
 ||kafan.cn
@@ -345,6 +358,7 @@
 ||knownsec.com
 ||krspace.cn
 ||ku6.com
+||kuaidi100.com
 ||kuaizhan.com
 
 ! L
@@ -419,6 +433,7 @@
 ||nga.cn
 ||ngacn.cc
 ||nuomi.com
+||nutrition.org
 ||nvidia.cn
 
 ! O
@@ -437,6 +452,7 @@
 ! P
 ||paipai.com
 ||panda.tv
+||pangu.io
 ||pcbeta.com
 ||pdcicons.ml
 ||pdim.gs
@@ -466,6 +482,8 @@
 ||qingting.fm
 ||qiniu.com
 ||qiniucdn.com
+||qiyi.com
+||qiyipic.com
 ||qiyukf.com
 ||qlogo.cn
 ||qnssl.com
@@ -494,14 +512,17 @@
 ||sandai.net
 ||sarm.net
 ||sb.sb
+||scichina.com
 ||sciencedirect.com
 ||sciencemag.org
 ||sciencenet.cn
+||scorecardresearch.com
 ||sdo.com
 ||seele.tech
 ||segmentfault.com
 ||sensorsdata.cn
 ||sf-express.com
+||shanbay.com
 ||shikezhi.com
 ||shimo.im
 ||shiyanlou.com
@@ -520,7 +541,9 @@
 ||smzdm.com
 ||so.com
 ||sogou.com
+||sogoucdn.com
 ||sohu.com
+||sohucs.com
 ||soku.com
 ||songshuhui.net
 ||soso.com
@@ -598,6 +621,7 @@
 ||waerfa.com
 ||wandoujia.com
 ||wanmei.com
+||wanplus.com
 ||webofknowledge.com
 ||weibo.com
 ||weidunewtab.com
@@ -617,6 +641,7 @@
 ||xiachufang.com
 ||xiami.com
 ||xiaomi.com
+||ximalaya.com
 ||xinhuanet.com
 ||xitu.io
 ||xldns.net


### PR DESCRIPTION
5eplay.com 和 5ewin.com：游戏平台5E相关
abchina.com：中国农业银行
basechem.org：物竞化学品数据库
biaozhuns.com：查询生物化工等行业标准品的数据
caixin.com：财新网
ch.com：春秋航空
changba：唱吧
cqvip.com：维普网
gaokao.com：高考网
huomaotv.com：火猫直播相关
iqiyipic.com、qiyi.com、qiyipic.com：爱奇艺相关
jstor.org：学术期刊网站
kuaidi100.com：快递100
nutrition.org：学术网站
pangu.io：iOS盘古越狱
scichina.com：《中国科学》杂志社
scorecardresearch.com：爱奇艺相关
shanbay.com：扇贝单词
sogoucdn.com、sohucs.com：搜狐搜狗相关
wanplus.com：玩加电竞
ximalaya.com：喜马拉雅FM