### PR TITLE
加入金山软件和超星网络

### DIFF
--- a/gfw_whitelist.txt
+++ b/gfw_whitelist.txt
@@ -2,6 +2,7 @@
 /.+\.com\.cn/
 /.+ac.cn/
 /.+acs.cn/
+/.+chaoxing.com/
 /.+edu.cn/
 /.+gov.cn/
 /.+net.cn/
@@ -306,6 +307,7 @@
 ||ifeng.com
 ||ifengimg.com
 ||iguxuan.com
+||ijinshan.com
 ||iknoworld.net
 ||im9.com
 ||imiku.me
@@ -351,6 +353,7 @@
 ||kankan.com
 ||kekenet.com
 ||kf5.com
+||kingsoft.com
 ||kmf.com
 ||knownsec.com
 ||krspace.cn


### PR DESCRIPTION
由于很多学校教学平台都是用超星网络开发的，所以用了正则表达式。其他两个是金山软件相关。