### PR TITLE
add cn.vuejs.org

### DIFF
--- a/gfw_whitelist.txt
+++ b/gfw_whitelist.txt
@@ -174,6 +174,7 @@
 ||cli.im
 ||cloudinary.com
 ||cloudxns.net
+||cn.vuejs.org
 ||cnbeta.com
 ||cnblogs.com
 ||cnki.net


### PR DESCRIPTION
加入vue中文版官网。访问官网 [https://cn.vuejs.org/](https://cn.vuejs.org/)。vue中文官网视频是优酷上的，所以走代理没有意义。